### PR TITLE
호텔 페이지 빈 편지함 에러 해결 및 조건별 편지 태그 분리

### DIFF
--- a/src/components/Mail.tsx
+++ b/src/components/Mail.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 
 function Mail({
   mail,
+  isEmpty = false,
   src,
   alt,
   link,
@@ -13,6 +14,7 @@ function Mail({
   src: string;
   alt: string;
   link: string;
+  isEmpty?: boolean;
 }) {
   const navigate = useNavigate();
 
@@ -30,6 +32,14 @@ function Mail({
       transform: mail ? 'scale(100%)' : 'scale(120%)',
     }),
   });
+
+  if (isEmpty) {
+    return (
+      <li css={mailButton}>
+        <img css={{ width: '100%', height: 'auto' }} src={src} alt={alt} />
+      </li>
+    );
+  }
 
   return (
     <button css={mailButton} type="button" onClick={() => navigate(link)}>

--- a/src/pages/Hotel.tsx
+++ b/src/pages/Hotel.tsx
@@ -109,15 +109,7 @@ export default function Hotel() {
     }
   }, [myInfo]);
 
-  // TODO: 페이지네이션 - case 분리
   useEffect(() => {
-    if (letterData?.length === 0) {
-      const emptyData = Array(limit)
-        .fill(0)
-        .map((v, i) => v + i);
-      setEmptyData(emptyData);
-    }
-
     if (letterData && letterData?.length % limit != 0) {
       const emptyData = Array(limit - (letterData!.length % limit))
         .fill(0)
@@ -188,14 +180,30 @@ export default function Hotel() {
               />
             </li>
           ))}
-          {/* TODO: data [] case 분리 */}
-          {page === numPages &&
-            emptyData!.length > 0 &&
-            emptyData!.map((_, index) => (
-              <li key={index}>
-                <Mail mail={true} src={empty} alt="미확인 편지" link="/hotel" />
-              </li>
-            ))}
+          {page === numPages
+            ? emptyData!.length > 0 &&
+              emptyData!.map((_, index) => (
+                <li key={index}>
+                  <Mail
+                    mail={true}
+                    src={empty}
+                    alt="미확인 편지"
+                    link="/hotel"
+                  />
+                </li>
+              ))
+            : Array(limit)
+                .fill(0)
+                .map((_, index) => (
+                  <li key={index}>
+                    <Mail
+                      mail={true}
+                      src={empty}
+                      alt="미확인 편지"
+                      link="/hotel"
+                    />
+                  </li>
+                ))}
           <p css={hotelNameWrapper}>{hotelName} HOTEL</p>
           {page > 1 && (
             <footer css={footerlayout}>

--- a/src/pages/Hotel.tsx
+++ b/src/pages/Hotel.tsx
@@ -183,26 +183,26 @@ export default function Hotel() {
           {page === numPages
             ? emptyData!.length > 0 &&
               emptyData!.map((_, index) => (
-                <li key={index}>
-                  <Mail
-                    mail={true}
-                    src={empty}
-                    alt="미확인 편지"
-                    link="/hotel"
-                  />
-                </li>
+                <Mail
+                  key={index}
+                  mail
+                  isEmpty
+                  src={empty}
+                  alt="미확인 편지"
+                  link="/hotel"
+                />
               ))
             : Array(limit)
                 .fill(0)
                 .map((_, index) => (
-                  <li key={index}>
-                    <Mail
-                      mail={true}
-                      src={empty}
-                      alt="미확인 편지"
-                      link="/hotel"
-                    />
-                  </li>
+                  <Mail
+                    key={index}
+                    mail
+                    isEmpty
+                    src={empty}
+                    alt="미확인 편지"
+                    link="/hotel"
+                  />
                 ))}
           <p css={hotelNameWrapper}>{hotelName} HOTEL</p>
           {page > 1 && (


### PR DESCRIPTION
**fix**
- 편지가 없을 경우 limit 길이의 배열을 리스트 렌더링해 빈 편지함 페인팅

**feat**
- 미확인 편지인 경우 `isEmpty` props true값이므로 `li` 태그
- 새로운 편지 또는 확인 편지인 경우 `li > button` 태그