### PR TITLE
받는/보낸편지함 페이지 UI 수정

### DIFF
--- a/src/pages/Received.tsx
+++ b/src/pages/Received.tsx
@@ -162,10 +162,11 @@ const srOnly = css({
 const background = css({
   position: 'relative',
   width: '100%',
-  height: '100%',
+  minWidth: '22.5rem', // 380px
+  height: '100lvh',
   background: '#FFC7BA',
   paddingTop: '2rem',
-  paddingBottom: '150px',
+  // paddingBottom: '150px',
 });
 
 const name = mq({
@@ -183,10 +184,14 @@ const name = mq({
   textOverflow: 'ellipsis',
 });
 
-// TODO: 3, 4 mq 편지함 repeat: 5, 6, ...
 const gridLayout = mq({
   display: 'grid',
-  gridTemplateColumns: ['repeat(3, 1fr)', 'repeat(4, 1fr)'],
+  gridTemplateColumns: [
+    'repeat(3, 1fr)',
+    'repeat(4, 1fr)',
+    'repeat(5, 1fr)',
+    'repeat(6, 1fr)',
+  ],
   rowGap: ['0.75rem', '1rem'],
 });
 
@@ -201,8 +206,8 @@ const nameAnimationLayout = css({
 });
 
 const namePlate = mq({
-  width: ['6.25rem', '7.375rem', '9.6875rem', '10.625rem'],
-  height: ['2.25rem', '2.625rem', '3.5625rem', '4.0625rem'],
+  width: ['6.25rem', '7.375rem'],
+  height: ['2.25rem', '2.625rem'],
   background: `url('./namePlate.png') no-repeat center / cover`,
 });
 
@@ -238,12 +243,11 @@ const namePlateLine = mq({
   background: '#A78F6C',
 });
 
-// TODO: 3, 4 mq 편지함 정사각형 사이즈로 변경
 const letterBox = mq({
   position: 'relative',
-  width: ['25lvw', '20lvw', '20lvw', '18lvw'],
-  maxWidth: '13.125rem',
-  height: ['15lvh', '15lvh', '18lvh', '20lvh'],
+  width: ['25lvw', '20lvw', '15lvw', '14lvw'],
+  maxWidth: ['7.5rem', '8.125rem', '13.125rem', '9.0625rem'],
+  height: ['15lvh', '17lvh', '18lvh', '20lvh'],
   background: `${Common.colors.lightMint}`,
   '& img': {
     position: 'absolute',

--- a/src/pages/Received.tsx
+++ b/src/pages/Received.tsx
@@ -9,6 +9,7 @@ import LetterPagination from '@/components/LetterPagination';
 import MenuButton from '@/components/MenuButton';
 import { myInfoState } from '@/recoil/atom/useFriend';
 import { debounce } from '@/util/debounce';
+import { throttle } from '@/util/throttle';
 import { letterSentRecent } from '@/util/letterSentRecent';
 import { mq } from '@/style/mq';
 import { Common } from '@/style/Common';
@@ -27,9 +28,7 @@ export default function Received() {
   const [emptyData, setEmptyData] = useState<Array<number> | null>([]);
   const [hover, setHover] = useState<number | null>(null);
 
-  // 페이지네이션
-  // TODO: mq 1) 12, 2) 16, 3) 20, 4) 24
-  // TODO: mq 12 페이지네이션 기준 -> max 24 편지함
+  /* 페이지네이션 변수 */
   const [limit, setLimit] = useState(12);
   const [page, setPage] = useState(1);
   const offset = (page - 1) * limit;
@@ -63,18 +62,26 @@ export default function Received() {
 
   /* 페이지네이션 편지함 기본 개수 지정 */
   useEffect(() => {
-    const width = window.innerWidth;
-    if (width < 768) {
-      setLimit(12);
-    } else if (width >= 768 && width <= 992) {
-      setLimit(16);
-    } else if (width <= 1200) {
-      setLimit(20);
-    } else {
-      setLimit(24);
-    }
-    return () => {};
-  });
+    const updateLimit = () => {
+      const width = window.innerWidth;
+      if (width <= 768) {
+        setLimit(12);
+      } else if (width <= 992) {
+        setLimit(15);
+      } else {
+        setLimit(18);
+      }
+    };
+
+    const throttledUpdateLimit = throttle(updateLimit);
+
+    updateLimit();
+    window.addEventListener('resize', throttle(throttledUpdateLimit));
+
+    return () => {
+      window.removeEventListener('resize', throttledUpdateLimit);
+    };
+  }, []);
 
   /* 페이지네이션 빈 편지함 개수 계산 */
   useEffect(() => {
@@ -176,7 +183,7 @@ const srOnly = css({
   margin: '-1px',
 });
 
-const background = css({
+const background = mq({
   position: 'relative',
   width: '100%',
   minWidth: '22.5rem', // 380px
@@ -184,7 +191,7 @@ const background = css({
   minHeight: '100lvh',
   background: '#FFC7BA',
   paddingTop: '2rem',
-  paddingBottom: '50px',
+  paddingBottom: ['4rem', '1rem', '2rem', '5rem'],
   overflow: 'hidden',
 });
 
@@ -266,17 +273,17 @@ const letterBox = mq({
   position: 'relative',
   width: ['25lvw', '20lvw', '15lvw', '14lvw'],
   maxWidth: ['7.5rem', '8.125rem', '13.125rem', '9.0625rem'],
-  minWidth: ['5.625rem', '7.1875rem', '8.625rem', '9.0625rem'],
+  minWidth: ['6rem', '7.1875rem', '8.625rem', '9.0625rem'],
   height: ['15lvh', '17lvh', '18lvh', '20lvh'],
-  maxHeight: ['7.75rem', '8.125rem', '8.75rem', '9.0625rem'],
-  minHeight: ['6.875rem', '7.8125rem', '8.3125rem', '9.1875rem'],
+  maxHeight: ['8.5rem', '8.125rem', '8.75rem', '9.0625rem'],
+  minHeight: ['6rem', '7.8125rem', '8.3125rem', '9.1875rem'],
   background: `${Common.colors.lightMint}`,
   '& img': {
     position: 'absolute',
     bottom: '0',
     left: '50%',
-    width: ['5rem', '5rem', '6.25rem', '7.5rem'],
-    height: ['5rem', '5rem', '6.25rem', '7.5rem'],
+    width: ['5.625rem', '6.25rem', '6.875rem', '7.8125rem'],
+    height: ['6.25rem', '6.875rem', '7.5rem', '8.75rem'],
     transform: 'translateX(-50%)',
     objectFit: 'cover',
   },

--- a/src/pages/Received.tsx
+++ b/src/pages/Received.tsx
@@ -28,9 +28,9 @@ export default function Received() {
   const [hover, setHover] = useState<number | null>(null);
 
   // 페이지네이션
-  // TODO: mq 1) 12, 2) 24
+  // TODO: mq 1) 12, 2) 16, 3) 20, 4) 24
   // TODO: mq 12 페이지네이션 기준 -> max 24 편지함
-  const [limit] = useState(12);
+  const [limit, setLimit] = useState(12);
   const [page, setPage] = useState(1);
   const offset = (page - 1) * limit;
 
@@ -61,7 +61,22 @@ export default function Received() {
     fetchReceived();
   }, [myInfo]);
 
-  /* 페이지네이션 */
+  /* 페이지네이션 편지함 기본 개수 지정 */
+  useEffect(() => {
+    const width = window.innerWidth;
+    if (width < 768) {
+      setLimit(12);
+    } else if (width >= 768 && width <= 992) {
+      setLimit(16);
+    } else if (width <= 1200) {
+      setLimit(20);
+    } else {
+      setLimit(24);
+    }
+    return () => {};
+  });
+
+  /* 페이지네이션 빈 편지함 개수 계산 */
   useEffect(() => {
     if (receivedData && receivedData?.length % limit != 0) {
       const emptyData = Array(limit - (receivedData!.length % limit))
@@ -165,10 +180,12 @@ const background = css({
   position: 'relative',
   width: '100%',
   minWidth: '22.5rem', // 380px
-  height: '100lvh',
+  height: '100%',
+  minHeight: '100lvh',
   background: '#FFC7BA',
   paddingTop: '2rem',
-  // paddingBottom: '150px',
+  paddingBottom: '50px',
+  overflow: 'hidden',
 });
 
 const name = mq({
@@ -256,7 +273,7 @@ const letterBox = mq({
   background: `${Common.colors.lightMint}`,
   '& img': {
     position: 'absolute',
-    bottom: '10%',
+    bottom: '0',
     left: '50%',
     width: ['5rem', '5rem', '6.25rem', '7.5rem'],
     height: ['5rem', '5rem', '6.25rem', '7.5rem'],
@@ -266,11 +283,11 @@ const letterBox = mq({
 });
 
 const deliveryMan = mq({
-  position: 'fixed',
+  position: 'absolute',
   left: '50%',
-  bottom: '-6lvh',
+  bottom: '-50px',
   width: ['35lvw', '30lvw'],
-  maxWidth: '11.25rem',
+  maxWidth: ['9.0625rem', '11.25rem'],
   transform: 'translateX(-50%)',
 });
 

--- a/src/pages/Received.tsx
+++ b/src/pages/Received.tsx
@@ -34,6 +34,7 @@ export default function Received() {
   const [page, setPage] = useState(1);
   const offset = (page - 1) * limit;
 
+  /* 받은 편지 가져오기 */
   useEffect(() => {
     const fetchReceived = async () => {
       try {
@@ -60,6 +61,7 @@ export default function Received() {
     fetchReceived();
   }, [myInfo]);
 
+  /* 페이지네이션 */
   useEffect(() => {
     if (receivedData && receivedData?.length % limit != 0) {
       const emptyData = Array(limit - (receivedData!.length % limit))
@@ -132,7 +134,7 @@ export default function Received() {
                 </div>
               ))}
       </div>
-      <img src="./mailMan.png" alt="배달원" css={frontMan} />
+      <img src="./mailMan.png" alt="배달원" css={deliveryMan} />
       <MenuButton sent />
       {page > 1 && (
         <footer css={footerlayout}>
@@ -247,7 +249,10 @@ const letterBox = mq({
   position: 'relative',
   width: ['25lvw', '20lvw', '15lvw', '14lvw'],
   maxWidth: ['7.5rem', '8.125rem', '13.125rem', '9.0625rem'],
+  minWidth: ['5.625rem', '7.1875rem', '8.625rem', '9.0625rem'],
   height: ['15lvh', '17lvh', '18lvh', '20lvh'],
+  maxHeight: ['7.75rem', '8.125rem', '8.75rem', '9.0625rem'],
+  minHeight: ['6.875rem', '7.8125rem', '8.3125rem', '9.1875rem'],
   background: `${Common.colors.lightMint}`,
   '& img': {
     position: 'absolute',
@@ -260,7 +265,7 @@ const letterBox = mq({
   },
 });
 
-const frontMan = mq({
+const deliveryMan = mq({
   position: 'fixed',
   left: '50%',
   bottom: '-6lvh',

--- a/src/pages/Sent.tsx
+++ b/src/pages/Sent.tsx
@@ -26,10 +26,11 @@ export default function Sent() {
   const [hover, setHover] = useState<number | null>(null);
 
   // 페이지네이션
-  const [limit] = useState(16);
+  const [limit] = useState(12);
   const [page, setPage] = useState(1);
   const offset = (page - 1) * limit;
 
+  /* 보낸 편지 가져오기 */
   useEffect(() => {
     const fetchSent = async () => {
       try {
@@ -56,6 +57,7 @@ export default function Sent() {
     fetchSent();
   }, [myInfo]);
 
+  /* 페이지네이션 */
   useEffect(() => {
     if (sentData && sentData?.length % limit != 0) {
       const emptyData = Array(limit - (sentData!.length % limit))
@@ -154,9 +156,10 @@ const srOnly = css({
 const background = css({
   position: 'relative',
   width: '100%',
-  height: '100%',
+  minWidth: '22.5rem', // 380px
+  height: '100lvh',
   background: `${Common.colors.brown}`,
-  padding: '2rem 0',
+  paddingTop: '2rem',
 });
 
 const name = mq({
@@ -176,7 +179,12 @@ const name = mq({
 
 const gridLayout = mq({
   display: 'grid',
-  gridTemplateColumns: ['repeat(3, 1fr)', 'repeat(4, 1fr)'],
+  gridTemplateColumns: [
+    'repeat(3, 1fr)',
+    'repeat(4, 1fr)',
+    'repeat(5, 1fr)',
+    'repeat(6, 1fr)',
+  ],
   rowGap: ['0.75rem', '1rem'],
 });
 
@@ -191,8 +199,8 @@ const nameAnimationLayout = css({
 });
 
 const namePlate = mq({
-  width: ['100px', '118px', '155px', '170px'],
-  height: ['36px', '42px', '57px', '65px'],
+  width: ['6.25rem', '7.375rem'],
+  height: ['2.25rem', '2.625rem'],
   background: `url('./namePlate.png') no-repeat center / cover`,
 });
 
@@ -230,16 +238,19 @@ const namePlateLine = mq({
 
 const letterBox = mq({
   position: 'relative',
-  width: ['25lvw', '20lvw', '20lvw', '18lvw'],
-  maxWidth: '13.125rem',
-  height: ['15lvh', '15lvh', '18lvh', '20lvh'],
+  width: ['25lvw', '20lvw', '18lvw'],
+  maxWidth: ['7.5rem', '8.125rem', '8.75rem', '9.0625rem'],
+  minWidth: ['5.625rem', '7.1875rem', '8.625rem', '9.0625rem'],
+  height: ['15lvh', '17lvh', '18lvh', '20lvh'],
+  maxHeight: ['7.75rem', '8.125rem', '8.75rem', '9.0625rem'],
+  minHeight: ['6.875rem', '7.8125rem', '8.3125rem', '9.1875rem'],
   background: `${Common.colors.darkBrown}`,
   '& img': {
     position: 'absolute',
     top: 0,
-    left: ['-1lvw', '8px'],
-    width: ['5.625rem', '5.625rem', '6.875rem', '7.8125rem'],
-    height: ['6.25rem', '6.25rem', '7.5rem', '8.75rem'],
+    left: ['-1lvw', '-0.5rem', 0, '-0.9375rem'],
+    width: ['5.625rem', '6.25rem', '6.875rem', '125px'],
+    height: ['6.25rem', '6.875rem', '7.5rem', '8.75rem'],
     objectFit: 'cover',
   },
 });

--- a/src/pages/Sent.tsx
+++ b/src/pages/Sent.tsx
@@ -157,9 +157,12 @@ const background = css({
   position: 'relative',
   width: '100%',
   minWidth: '22.5rem', // 380px
-  height: '100lvh',
+  height: '100%',
+  minHeight: '100lvh',
   background: `${Common.colors.brown}`,
   paddingTop: '2rem',
+  paddingBottom: '50px',
+  overflow: 'hidden',
 });
 
 const name = mq({
@@ -256,11 +259,11 @@ const letterBox = mq({
 });
 
 const frontMan = mq({
-  position: 'fixed',
+  position: 'absolute',
   left: '50%',
   bottom: 0,
   width: ['35lvw', '30lvw'],
-  maxWidth: '11.25rem',
+  maxWidth: ['9.0625rem', '11.25rem'],
   transform: 'translateX(-50%)',
 });
 

--- a/src/pages/Sent.tsx
+++ b/src/pages/Sent.tsx
@@ -9,6 +9,7 @@ import LetterPagination from '@/components/LetterPagination';
 import MenuButton from '@/components/MenuButton';
 import { myInfoState } from '@/recoil/atom/useFriend';
 import { debounce } from '@/util/debounce';
+import { throttle } from '@/util/throttle';
 import { letterSentRecent } from '@/util/letterSentRecent';
 import { mq } from '@/style/mq';
 import { Common } from '@/style/Common';
@@ -25,8 +26,8 @@ export default function Sent() {
   const [emptyData, setEmptyData] = useState<Array<number> | null>([]);
   const [hover, setHover] = useState<number | null>(null);
 
-  // 페이지네이션
-  const [limit] = useState(12);
+  /* 페이지네이션 변수 */
+  const [limit, setLimit] = useState(12);
   const [page, setPage] = useState(1);
   const offset = (page - 1) * limit;
 
@@ -56,6 +57,29 @@ export default function Sent() {
     };
     fetchSent();
   }, [myInfo]);
+
+  /* 페이지네이션 편지함 기본 개수 지정 */
+  useEffect(() => {
+    const updateLimit = () => {
+      const width = window.innerWidth;
+      if (width <= 768) {
+        setLimit(12);
+      } else if (width <= 992) {
+        setLimit(15);
+      } else {
+        setLimit(18);
+      }
+    };
+
+    const throttledUpdateLimit = throttle(updateLimit);
+
+    updateLimit();
+    window.addEventListener('resize', throttle(throttledUpdateLimit));
+
+    return () => {
+      window.removeEventListener('resize', throttledUpdateLimit);
+    };
+  }, []);
 
   /* 페이지네이션 */
   useEffect(() => {
@@ -153,7 +177,7 @@ const srOnly = css({
   margin: '-1px',
 });
 
-const background = css({
+const background = mq({
   position: 'relative',
   width: '100%',
   minWidth: '22.5rem', // 380px
@@ -161,7 +185,7 @@ const background = css({
   minHeight: '100lvh',
   background: `${Common.colors.brown}`,
   paddingTop: '2rem',
-  paddingBottom: '50px',
+  paddingBottom: ['4rem', '1rem', '2rem', '5rem'],
   overflow: 'hidden',
 });
 
@@ -243,16 +267,16 @@ const letterBox = mq({
   position: 'relative',
   width: ['25lvw', '20lvw', '18lvw'],
   maxWidth: ['7.5rem', '8.125rem', '8.75rem', '9.0625rem'],
-  minWidth: ['5.625rem', '7.1875rem', '8.625rem', '9.0625rem'],
+  minWidth: ['6rem', '7.1875rem', '8.625rem', '9.0625rem'],
   height: ['15lvh', '17lvh', '18lvh', '20lvh'],
   maxHeight: ['7.75rem', '8.125rem', '8.75rem', '9.0625rem'],
-  minHeight: ['6.875rem', '7.8125rem', '8.3125rem', '9.1875rem'],
+  minHeight: ['6rem', '7.8125rem', '8.3125rem', '9.1875rem'],
   background: `${Common.colors.darkBrown}`,
   '& img': {
     position: 'absolute',
     top: 0,
     left: ['-1lvw', '-0.5rem', 0, '-0.9375rem'],
-    width: ['5.625rem', '6.25rem', '6.875rem', '125px'],
+    width: ['5.625rem', '6.25rem', '6.875rem', '7.8125rem'],
     height: ['6.25rem', '6.875rem', '7.5rem', '8.75rem'],
     objectFit: 'cover',
   },


### PR DESCRIPTION
### 편지함 grid 배치 및 UI 수정
- 미디어쿼리에 따른 데스크탑 사이즈 3, 4 (mq.tsx 참고) grid 열 4 -> 5, 4 -> 6 으로 수정
- 편지함 세로로 긴 직사각형 -> 정사각형 디자인
- 편지함 width, height 속성 각각 min, max 값 추가

### 미디어쿼리에 따른 기본 편지함 개수 변경 작업
- 설정된 미디어쿼리(mq.ts 참고)에 따른 편지함 개수 변화 `[12, 12, 15, 18]`
- `throttle` 성능 최적화